### PR TITLE
Update xiaomi_dns_block.lst

### DIFF
--- a/xiaomi_dns_block.lst
+++ b/xiaomi_dns_block.lst
@@ -225,7 +225,6 @@ tracking.miui.com
 trial.api.huangye.miui.com
 tv.app.migc.xiaomi.com
 update.avlyun.sec.miui.com
-update.miui.com
 upgrade.mishop.pandora.xiaomi.com
 us-api-micloud-xiaomi-net-5630734.us-west-2.elb.amazonaws.com
 us.api.micloud.xiaomi.net


### PR DESCRIPTION
Removed update.miui.com as it is used for Updates of the Firmware (android updates)