### PR TITLE
Update xiaomi_dns_block.lst

### DIFF
--- a/xiaomi_dns_block.lst
+++ b/xiaomi_dns_block.lst
@@ -257,3 +257,6 @@ zeus.ad.xiaomi.com
 zhuti.xiaomi.com
 zx.game.xiaomi.com
 zx.game.xiaomi.comstat.xiaomi.com
+110.43.0.85
+110.43.0.83
+http://dlg.io.mi.com

--- a/xiaomi_dns_block.lst
+++ b/xiaomi_dns_block.lst
@@ -126,6 +126,7 @@ huodong.xiaomi.com
 huosai.xiaomi.com
 i.mi.com
 i.xiaomi.com
+io.mi.com
 idmb.app.chat.global.xiaomi.net
 igame.xiaomi.com
 image.pandora.xiaomi.com
@@ -257,6 +258,4 @@ zeus.ad.xiaomi.com
 zhuti.xiaomi.com
 zx.game.xiaomi.com
 zx.game.xiaomi.comstat.xiaomi.com
-110.43.0.85
-110.43.0.83
-http://dlg.io.mi.com
+


### PR DESCRIPTION
please add:

dlg.io.mi.com

these where hard coded in the Xiaomi Air Purifier Firmware. Source: https://flamingo-tech.nl/2021/05/03/xiaomi-air-purifier-3h-reverse-engineering-part-3-esp32-dump/

these are used for call back and sending information back to China...